### PR TITLE
Fix checking of get object exception

### DIFF
--- a/jwt_devices/views.py
+++ b/jwt_devices/views.py
@@ -77,7 +77,7 @@ class DeviceLogout(DestroyAPIView):
     def get_object(self):
         try:
             return self.get_queryset().get(user=self.request.user, id=self.request.META["HTTP_DEVICE_ID"])
-        except KeyError:
+        except (KeyError, ValueError):
             raise ValidationError(_("Device-Id header must be present in the request headers."))
         except Device.DoesNotExist:
             raise NotFound(_("Device does not exist."))


### PR DESCRIPTION
This brings the fix from cc0661f5e08162dfd1ce4323af2b21ed79076208 back into the master branch. This commit was never merged into master, but was used to tag the current most recent release that is being used in production. At the same time master has moved on and is documenting a different 1.2.1 release.

After this merges I plan on updating release tags and unifying the history under 1.2.2