### PR TITLE
Bump release for 1.2.2

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.2.2] - 2019-09-09
+### Fixed
+- fixed exception check in views
+
 ## [1.2.1] - 2018-10-25
 ### Added
 - a test to enforce completeness of migrations

--- a/jwt_devices/__init__.py
+++ b/jwt_devices/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = "Django Rest Framework JWT Devices"
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __author__ = "Michal Proszek"
 __license__ = "MIT"
 __copyright__ = "Copyright 2017-2018 Arabella"


### PR DESCRIPTION
This updates the release tags in this repo in preparation for a 1.2.2 release.

I plan on tagging a github release once this merges for 1.2.2 and also pushing a new pypi package as well.

As mentioned in #7 the history in this github repo does not match the changelog because there was a release pushed from a non master branch. This PR does not address the incorrect history, but moves on to a unified history that contains all changes.